### PR TITLE
Made it so the counts below list items are actually accurate.

### DIFF
--- a/Server/Backend.DataAccess/Repositories/RegionRepository.cs
+++ b/Server/Backend.DataAccess/Repositories/RegionRepository.cs
@@ -45,7 +45,8 @@ namespace Backend.DataAccess.Repositories
                             Id = s.Id,
                             Name = s.Name,
                             IsDeleted = s.IsMarkedAsDeleted,
-                            RegionId = s.RegionId
+                            RegionId = s.RegionId,
+                            ItemCount = s.Items.Count
                         }).ToList()
                 })
                 //load the data

--- a/Server/Backend/Controllers/ItemsController.cs
+++ b/Server/Backend/Controllers/ItemsController.cs
@@ -46,7 +46,6 @@ namespace Backend.Controllers
         /// </summary>
         /// <returns>A list of items.</returns>
         /// <param name="stationId">The id of the station.</param>
-        //[RoutePrefix("/stations")]
         [Route("~/api/stations/{stationId}/items")]
         [SwaggerOperation(Tags = new[] { StationsController.SwaggerName })]
         public async Task<IHttpActionResult> Get(Guid stationId)

--- a/Shared/Mobile-Rounds.ViewModels/Models/RegionModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Models/RegionModel.cs
@@ -35,6 +35,6 @@ namespace Mobile_Rounds.ViewModels.Models
         /// <summary>
         /// A list of stations that are inside this region.
         /// </summary>
-        public IEnumerable<StationModel> Stations { get; set; }
+        public List<StationModel> Stations { get; set; }
     }
 }

--- a/Shared/Mobile-Rounds.ViewModels/Models/StationModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Models/StationModel.cs
@@ -34,6 +34,23 @@ namespace Mobile_Rounds.ViewModels.Models
         public bool IsDeleted { get; set; }
 
         /// <summary>
+        /// The count of nested items.
+        /// </summary>
+        public int ItemCount { get; set; }
+
+        public string ItemCountString
+        {
+            get
+            {
+                if (ItemCount != 1)
+                {
+                    return $"{ItemCount} Items";
+                }
+                return $"{ItemCount} Item";
+            }
+        }
+
+        /// <summary>
         /// The list of items in this given station. Obtained
         /// by calling the /api/station/id endpoint.
         /// </summary>

--- a/Shared/Mobile-Rounds.ViewModels/Regular/ReadingInput/ReadingInputViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/ReadingInput/ReadingInputViewModel.cs
@@ -138,11 +138,11 @@ namespace Mobile_Rounds.ViewModels.Regular.ReadingInput
 
                 if (this.todaysData.ValueBounds == BoundType.GreaterThan)
                 {
-                    return $"> {this.todaysData.MinimumValue} {this.todaysData.UnitAbbreviation}";
+                    return $"> {this.todaysData.MaximumValue} {this.todaysData.UnitAbbreviation}";
                 }
                 if (this.todaysData.ValueBounds == BoundType.GreaterThanOrEqual)
                 {
-                    return $">= {this.todaysData.MinimumValue} {this.todaysData.UnitAbbreviation}";
+                    return $">= {this.todaysData.MaximumValue} {this.todaysData.UnitAbbreviation}";
                 }
 
                 if (this.todaysData.ValueBounds == BoundType.LessThan)

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionListViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionListViewModel.cs
@@ -51,7 +51,8 @@ namespace Mobile_Rounds.ViewModels.Regular.Region
                 this.Regions.Add(new RegionModelSource()
                 {
                     Id = region.Id,
-                    Name = region.Name
+                    Name = region.Name,
+                    Stations = region.Stations
                 });
             }
         }

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionModelSource.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionModelSource.cs
@@ -1,4 +1,5 @@
-﻿using Mobile_Rounds.ViewModels.Platform;
+﻿using Mobile_Rounds.ViewModels.Models;
+using Mobile_Rounds.ViewModels.Platform;
 using Mobile_Rounds.ViewModels.Regular.Station;
 using Mobile_Rounds.ViewModels.Shared;
 using Mobile_Rounds.ViewModels.Shared.Commands;
@@ -17,13 +18,27 @@ namespace Mobile_Rounds.ViewModels.Regular.Region
         public AsyncCommand Navigate { get; private set; }
         public Guid Id { get; set; }
 
+        public List<StationModel> Stations { get; set; }
+
+        public string StationCountText
+        {
+            get
+            {
+                if (Stations.Count != 1)
+                {
+                    return $"{Stations.Count} Stations";
+                }
+                return $"{Stations.Count} Station";
+            }
+        }
+
         public RegionModelSource()
         {
-            this.Navigate = new AsyncCommand(async(obj) =>
+            this.Navigate = new AsyncCommand((obj) =>
             {
-                var file = Platform.ServiceResolver.Resolve<IFileHandler>();
-                var reads = await file.GetFileAsync("stations.json");
-                var vm = new StationListViewModel(reads, this);
+                //var file = Platform.ServiceResolver.Resolve<IFileHandler>();
+                //var reads = await file.GetFileAsync("stations.json");
+                var vm = new StationListViewModel(this);
                 BaseViewModel.Navigator.Navigate(Shared.Navigation.NavigationType.StationSelect, vm);
             });
         }

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Station/StationListViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Station/StationListViewModel.cs
@@ -35,21 +35,19 @@ namespace Mobile_Rounds.ViewModels.Regular.Station
             }
         }
 
-        public StationListViewModel(string reads, RegionModelSource region)
+        public StationListViewModel(RegionModelSource region)
         {
             this.Crumbs.Add(new Shared.Controls.BreadcrumbItemModel(region.Name, region.Navigate));
             this.Stations = new ObservableCollection<StationModel>();
-            var result = JsonConvert.DeserializeObject<StationHandler>(reads);
-            foreach (var station in result.Stations)
+            //var result = JsonConvert.DeserializeObject<StationHandler>(reads);
+            foreach (var station in region.Stations)
             {
-                if (station.RegionId == region.Id)
+                this.Stations.Add(new StationModel(region)
                 {
-                    this.Stations.Add(new StationModel(region)
-                    {
-                        Id = station.Id,
-                        Name = station.Name
-                    });
-                }
+                    Id = station.Id,
+                    Name = station.Name,
+                    ItemCount = station.ItemCount
+                });
             }
         }
 

--- a/Tablet/Mobile-Rounds/Screens/Regular/RegionScreen.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Regular/RegionScreen.xaml
@@ -77,7 +77,7 @@
                             FontSize="30" Padding="5"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="0"
-                            Text="2 items"
+                            Text="{Binding StationCountText}"
                             Foreground="Black" 
                             Padding="5,0,0,5"
                             HorizontalAlignment="Stretch"

--- a/Tablet/Mobile-Rounds/Screens/Regular/StationScreen.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Regular/StationScreen.xaml
@@ -76,7 +76,7 @@
                             FontSize="30" Padding="5"/>
 
                         <TextBlock Grid.Row="1" Grid.Column="0"
-                            Text="3 items"
+                            Text="{Binding ItemCountString}"
                             Foreground="Black" 
                             Padding="5,0,0,5"
                             HorizontalAlignment="Stretch"


### PR DESCRIPTION
Closes #96. This also has some minor refactoring to utilize the region base list to populate information about the stations. So since the API returns a list of regions as well as all the stations per region (plus the count of the items in each station), there is not really a need for a secondary `stations.json` file. We can cut down on the IO time by removing this file, which is what I am doing now and it works just fine thus far.