### PR TITLE
Feature/user admin check

### DIFF
--- a/Server/Backend/App_Start/NinjectWebCommon.cs
+++ b/Server/Backend/App_Start/NinjectWebCommon.cs
@@ -10,6 +10,8 @@ using Ninject;
 using Ninject.Web.Common;
 using Ninject.Web.WebApi;
 using Microsoft.Web.Infrastructure.DynamicModuleHelper;
+using System.Configuration;
+using System.Collections.Generic;
 
 [assembly: WebActivatorEx.PreApplicationStartMethod(typeof(AgencyRM.Tracker.App_Start.NinjectWebCommon), "Start")]
 [assembly: WebActivatorEx.ApplicationShutdownMethodAttribute(typeof(AgencyRM.Tracker.App_Start.NinjectWebCommon), "Stop")]
@@ -71,8 +73,21 @@ namespace AgencyRM.Tracker.App_Start
         private static void RegisterServices(IKernel kernel)
         {
             kernel.Bind<DatabaseContext>()
-                .ToConstructor((ctx) => new DatabaseContext("DevDatabase"))
+                .ToConstructor((ctx) => new DatabaseContext("Database"))
                 .InRequestScope();
+
+            kernel.Bind<Dictionary<string, string>>()
+                .ToMethod((ctx) =>
+                {
+                    Dictionary<string, string> settings = new Dictionary<string, string>();
+                    foreach (var key in ConfigurationManager.AppSettings.AllKeys)
+                    {
+                        string val = ConfigurationManager.AppSettings[key].ToString();
+                        settings.Add(key, val);
+                    }
+                    return settings;
+                });
+
         }
     }
 }

--- a/Server/Backend/Backend.csproj
+++ b/Server/Backend/Backend.csproj
@@ -164,6 +164,7 @@
     <Compile Include="Controllers\UnitOfMeasuresController.cs" />
     <Compile Include="Controllers\RegionsController.cs" />
     <Compile Include="Controllers\StationsController.cs" />
+    <Compile Include="Controllers\UsersController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebApiApplication.asax.cs" />
   </ItemGroup>

--- a/Server/Backend/Controllers/UsersController.cs
+++ b/Server/Backend/Controllers/UsersController.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using System.Web.Http;
+using Mobile_Rounds.ViewModels.Models;
+using Swashbuckle.Swagger.Annotations;
+
+namespace Backend.Controllers
+{
+    /// <summary>
+    /// The entrypoint into the users resources.
+    /// </summary>
+    [RoutePrefix("api/users")]
+    [Authorize]
+    public class UsersController : ApiController
+    {
+        private const string SwaggerName = "Users";
+        private readonly Dictionary<string, string> settings;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UsersController"/> class.
+        /// </summary>
+        /// <param name="settings">The app settings from the Web.config.</param>
+        public UsersController(Dictionary<string, string> settings)
+        {
+            this.settings = settings;
+        }
+
+        /// <summary>
+        /// Gets the metadata for the logged in user.
+        /// </summary>
+        /// <returns>The logged in users metadata.</returns>
+        [Route("")]
+        [SwaggerOperation(Tags = new[] { SwaggerName })]
+        public IHttpActionResult Get()
+        {
+            var ident = this.RequestContext.Principal;
+            var user = new UserModel
+            {
+                Email = ident.Identity.Name,
+                IsAdministrator = ident.IsInRole(this.settings["AppAdminGroup"])
+            };
+
+            return this.Ok(user);
+        }
+    }
+}

--- a/Server/Backend/Web.config
+++ b/Server/Backend/Web.config
@@ -9,13 +9,16 @@
     <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
   </configSections>
   <connectionStrings>
-    <add name="DevDatabase" connectionString="data source=(LocalDB)\MSSQLLocalDB;attachdbfilename=|DataDirectory|\Databases\DevDatabase.mdf;integrated security=True;connect timeout=30;MultipleActiveResultSets=True;" providerName="System.Data.SqlClient" />
+    <add name="Database" connectionString="data source=(LocalDB)\MSSQLLocalDB;attachdbfilename=|DataDirectory|\Databases\DevDatabase.mdf;integrated security=True;connect timeout=30;MultipleActiveResultSets=True;" providerName="System.Data.SqlClient" />
   </connectionStrings>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
+    
+    <!--BEGIN APP SETTINGS-->
+    <add key="AppAdminGroup" value="Administrators"/>
   </appSettings>
   <!--
     For a description of web.config changes see http://go.microsoft.com/fwlink/?LinkId=235367.

--- a/Shared/Mobile-Rounds.ViewModels.Tests/Shared/Home/HomePageViewModelTests.cs
+++ b/Shared/Mobile-Rounds.ViewModels.Tests/Shared/Home/HomePageViewModelTests.cs
@@ -10,6 +10,24 @@ using System.Threading.Tasks;
 
 namespace Mobile_Rounds.ViewModels.Tests.Shared.Home
 {
+    class TestSettings : ISettings
+    {
+        private object val;
+        public TestSettings(object value)
+        {
+            val = value;
+        }
+        public TReturn GetValue<TReturn>(string key)
+        {
+            return (TReturn)val;
+        }
+
+        public void SaveValue(string key, object value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
     [TestClass]
     public class HomePageViewModelTests
     {
@@ -18,7 +36,7 @@ namespace Mobile_Rounds.ViewModels.Tests.Shared.Home
         {
             //register dummy api request type.
             ServiceResolver.Register<IApiRequest>(() => null);
-            ServiceResolver.Register<ISettings>(() => null);
+            ServiceResolver.Register<ISettings>(() => new TestSettings(true));
         }
 
         [TestMethod]

--- a/Shared/Mobile-Rounds.ViewModels/Mobile-Rounds.ViewModels.csproj
+++ b/Shared/Mobile-Rounds.ViewModels/Mobile-Rounds.ViewModels.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Models\SpecificationModel.cs" />
     <Compile Include="Models\UnitOfMeasureModel.cs" />
     <Compile Include="Admin\UnitOfMeasure\UnitOfMeasureScreenViewModel.cs" />
+    <Compile Include="Models\UserModel.cs" />
     <Compile Include="Platform\Constants.cs" />
     <Compile Include="Platform\IApiRequest.cs" />
     <Compile Include="Platform\IBreadcrumbNavigationEvent.cs" />

--- a/Shared/Mobile-Rounds.ViewModels/Models/UserModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Models/UserModel.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Mobile_Rounds.ViewModels.Models
+{
+    /// <summary>
+    /// Represents the currently logged in user.
+    /// </summary>
+    public class UserModel
+    {
+        public UserModel()
+        {
+            IsAdministrator = false;
+        }
+
+        /// <summary>
+        /// The Users email address.
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value indicating if the user is an admin or not.
+        /// </summary>
+        public bool IsAdministrator { get; set; }
+    }
+}

--- a/Shared/Mobile-Rounds.ViewModels/Platform/Constants.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Platform/Constants.cs
@@ -9,6 +9,7 @@ namespace Mobile_Rounds.ViewModels.Platform
     public static class Constants
     {
         public const string APIHostConfigKey = "API_Host";
+        public const string UserAdminKey = "USER_Admin";
 
         public static class ApiOptions
         {
@@ -18,6 +19,7 @@ namespace Mobile_Rounds.ViewModels.Platform
 
         public static class Endpoints
         {
+            public const string Users = "/api/users";
             public const string Units = "/api/units";
             public const string Regions = "/api/regions";
             public const string Stations = "/api/stations";

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Configuration/ConfigurationViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Configuration/ConfigurationViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Mobile_Rounds.ViewModels.Platform;
+﻿using Mobile_Rounds.ViewModels.Models;
+using Mobile_Rounds.ViewModels.Platform;
 using Mobile_Rounds.ViewModels.Shared;
 using Mobile_Rounds.ViewModels.Shared.Commands;
 using System;
@@ -31,12 +32,17 @@ namespace Mobile_Rounds.ViewModels.Regular.Configuration
             this.Crumbs.Add(new Shared.Controls.BreadcrumbItemModel("Settings"));
             settings = ServiceResolver.Resolve<ISettings>();
             apiHost = settings.GetValue<string>(Constants.APIHostConfigKey);
-            Save = new AsyncCommand(SaveCommand, CanSave);
+            Save = new AsyncCommand(async (obj) => await this.SaveCommand(), CanSave);
         }
 
-        private void SaveCommand(object data)
+        private async Task SaveCommand()
         {
+            //save the api config.
             settings.SaveValue(Constants.APIHostConfigKey, this.ApiHost);
+
+            //now get the users metadata.
+            var userInfo = await base.Api.GetAsync<UserModel>(Constants.Endpoints.Users);
+            settings.SaveValue(Constants.UserAdminKey, userInfo.IsAdministrator);
         }
 
         private bool CanSave(object data)

--- a/Shared/Mobile-Rounds.ViewModels/Shared/Home/HomePageViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Shared/Home/HomePageViewModel.cs
@@ -68,10 +68,6 @@ namespace Mobile_Rounds.ViewModels.Shared.Home
         /// </summary>
         public HomePageViewModel()
         {
-#if DEBUG
-            // only make us admin if debugging.
-            this.IsAdmin = true;
-#endif
             this.GoHome = null;
 
             this.Sync = new AsyncCommand(async (obj) =>
@@ -104,7 +100,12 @@ namespace Mobile_Rounds.ViewModels.Shared.Home
             }, this.CanSync);
 
             this.StartRound = new StartRoundCommand();
-            
+            var settings = ServiceResolver.Resolve<ISettings>();
+            IsAdmin = settings.GetValue<bool>(Constants.UserAdminKey);
+
+#if DEBUG
+            IsAdmin = true;
+#endif
         }
 
         private bool CanSync(object sender)

--- a/Tablet/Mobile-Rounds/Screens/Regular/HomeScreen.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Regular/HomeScreen.xaml
@@ -52,7 +52,7 @@
             <controls:ColoredTile Foreground="White" Background="Purple" 
                                   Margin="10" Title="Admin"
                                   Command="{Binding GoToAdmin}"
-                                  Visibility="{Binding AdminTileVisibility}"
+                                  Visibility="{Binding IsAdmin, Mode=TwoWay, Converter={StaticResource BoolToVis}}"
                                   IsEnabled="{Binding CanProgress, Mode=TwoWay}"/>
 
             <controls:ColoredTile Foreground="White" Background="Purple" 

--- a/Tablet/Mobile-Rounds/Screens/Regular/HomeScreen.xaml.cs
+++ b/Tablet/Mobile-Rounds/Screens/Regular/HomeScreen.xaml.cs
@@ -16,6 +16,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
 
 namespace Mobile_Rounds.Screens.Regular
 {


### PR DESCRIPTION
Now the users metadata is returned when the application is first setup with the API url. Perhaps in the future this would be its own button in the settings page, but for now, it just happens automatically and is cached on the device for future use.
Closes #100 