### PR TITLE
Implemented API based data sync with admin items

### DIFF
--- a/Server/Backend.DataAccess/Repositories/ItemRepository.cs
+++ b/Server/Backend.DataAccess/Repositories/ItemRepository.cs
@@ -103,7 +103,7 @@ namespace Backend.DataAccess.Repositories
         protected override ItemModel BuildViewModel(Item model)
         {
             if (model == null) return null;
-            return new ItemModel
+            var item = new ItemModel
             {
                 Id = model.ItemId,
                 Name = model.Name,
@@ -125,7 +125,12 @@ namespace Backend.DataAccess.Repositories
                         IsDeleted = model.Specification.Unit.IsMarkedAsDeleted
                     }
                 },
-                PastFourReadings = model.Readings
+                PastFourReadings = new List<ReadingModel>()
+            };
+
+            if(model.Readings != null)
+            {
+                item.PastFourReadings = model.Readings?
                     .OrderBy(i => i.TimeTaken)
                     .Select(i => new ReadingModel
                     {
@@ -134,8 +139,10 @@ namespace Backend.DataAccess.Repositories
                         Value = i.Value,
                         Comments = i.Comments
                     })
-                    .Take(4)
-            };
+                    .Take(4);
+            }
+
+            return item;
         }
 
         protected override Item BuildModel(ItemModel model)
@@ -147,7 +154,16 @@ namespace Backend.DataAccess.Repositories
                 Name = model.Name,
                 IsMarkedAsDeleted = model.IsDeleted,
                 Meter = model.Meter,
-                StationId = model.StationId
+                StationId = model.StationId,
+                Specification = new Specification
+                {
+                    ItemId = model.Id,
+                    IsMarkedAsDeleted = model.IsDeleted,
+                    ComparisonTypeName = model.Specification.ComparisonType,
+                    LowerBoundValue = model.Specification.LowerBound,
+                    UpperBoundValue = model.Specification.UpperBound,
+                    UnitId = model.Specification.UnitOfMeasure.Id
+                }
             };
         }
     }

--- a/Server/Backend.Schemas/ComparisonType.cs
+++ b/Server/Backend.Schemas/ComparisonType.cs
@@ -11,9 +11,9 @@ namespace Backend.Schemas
     public class ComparisonType
     {
         public const string LessThan = "Less Than";
-        public const string LessThanOrEqual = "Less Than Or Equal";
+        public const string LessThanOrEqual = "Less Than Or Equal To";
         public const string GreaterThan = "Greater Than";
-        public const string GreaterThanOrEqual = "Greater Than Or Equal";
+        public const string GreaterThanOrEqual = "Greater Than Or Equal To";
         public const string EqualTo = "Equal To";
         public const string Between = "Between";
         public const string Either = "Either";

--- a/Server/Backend.Schemas/DatabaseContext.cs
+++ b/Server/Backend.Schemas/DatabaseContext.cs
@@ -34,7 +34,7 @@ namespace Backend.Schemas
             modelBuilder.Conventions.Remove<ManyToManyCascadeDeleteConvention>();
         }
 
-        public DatabaseContext() : this("DevDatabase") { }
+        public DatabaseContext() : this("Database") { }
 
         /// <summary>
         /// The <see cref="Region"/>'s table.

--- a/Server/Backend.Schemas/Seeding/ComparisonTypeSeeder.cs
+++ b/Server/Backend.Schemas/Seeding/ComparisonTypeSeeder.cs
@@ -11,21 +11,17 @@ namespace Backend.Schemas.Seeding
     {
         public void Seed(DatabaseContext ctx)
         {
-            if (!ctx.ComparisonTypes.Any())
-            {
-                ctx.ComparisonTypes.AddOrUpdate(t => t.Name,
-                    new ComparisonType { Name = ComparisonType.Between },
-                    new ComparisonType { Name = ComparisonType.Either },
-                    new ComparisonType { Name = ComparisonType.EqualTo },
-                    new ComparisonType { Name = ComparisonType.GreaterThan },
-                    new ComparisonType { Name = ComparisonType.GreaterThanOrEqual },
-                    new ComparisonType { Name = ComparisonType.LessThan },
-                    new ComparisonType { Name = ComparisonType.LessThanOrEqual },
-                    new ComparisonType { Name = ComparisonType.NotApplicable }
-                );
-                ctx.SaveChanges();
-            }
-
+            ctx.ComparisonTypes.AddOrUpdate(t => t.Name,
+                new ComparisonType { Name = ComparisonType.Between },
+                new ComparisonType { Name = ComparisonType.Either },
+                new ComparisonType { Name = ComparisonType.EqualTo },
+                new ComparisonType { Name = ComparisonType.GreaterThan },
+                new ComparisonType { Name = ComparisonType.GreaterThanOrEqual },
+                new ComparisonType { Name = ComparisonType.LessThan },
+                new ComparisonType { Name = ComparisonType.LessThanOrEqual },
+                new ComparisonType { Name = ComparisonType.NotApplicable }
+            );
+            ctx.SaveChanges();
         }
     }
 }

--- a/Shared/Mobile-Rounds.ViewModels/Admin/AdminHome/AdminHomeViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Admin/AdminHome/AdminHomeViewModel.cs
@@ -71,23 +71,7 @@ namespace Mobile_Rounds.ViewModels.Admin.AdminHome
             this.GoToItems = new AsyncCommand(async (obj) =>
             {
                 //TODO: This is a hack just for demonstration purposes.
-                var fm = ServiceResolver.Resolve<IFileHandler>();
-
-                var regions = await fm.GetFileAsync<RegionHandler>("regions.json");
-                var stations = await fm.GetFileAsync<StationHandler>("stations.json");
-                var items = await fm.GetFileAsync<ItemHandler>("items.json");
-                var units = await fm.GetFileAsync<UnitHandler>("units.json");
-
-                var east = regions.Regions[0];
-                var nox = stations.Stations.First(r => r.RegionId == east.Id);
-
-                var vm = new ViewModels.Admin.Items.ItemScreenViewModel(
-                    east,
-                    nox,
-                    units.Units,
-                    items.Items);
-
-                Navigator.Navigate(NavigationType.AdminItems, vm);
+                //Navigator.Navigate(NavigationType.AdminItems, vm);
             });
         }
     }

--- a/Shared/Mobile-Rounds.ViewModels/Admin/Items/ItemViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Admin/Items/ItemViewModel.cs
@@ -199,11 +199,35 @@ namespace Mobile_Rounds.ViewModels.Admin.Items
             //Value types for readings. Indicate what type of value a new unit will be.
             //Volts for example might be a Number, while a text based readout would be Text
             this.ModificationType = "Create";
-            this.Units = new ObservableCollection<UnitOfMeasureModel>(units);
+            this.Units = units;
             this.comparisonType = null;
             this.unit = null;
             this.Save = save;
             this.Cancel = cancel;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnitOfMeasureModel"/> class.
+        /// This then caches the save and cancel commands so that it can
+        /// notify any views based on them.
+        /// </summary>
+        /// <param name="model">The model data to copy.</param>
+        /// <param name="save">The save command that is based on this unit.</param>
+        /// <param name="cancel">The cancel command that is based on this unit.</param>
+        public ItemViewModel(ItemModel model, AsyncCommand save, AsyncCommand cancel, ObservableCollection<UnitOfMeasureModel> units)
+            : this(save, cancel, units)
+        {
+            this.Model = model;
+
+            this.Id = model.Id;
+            this.name = model.Name;
+            this.lowerBound = model.Specification.LowerBound;
+            this.upperBound = model.Specification.UpperBound;
+            this.unit = units.FirstOrDefault(u => u.Id == model.Specification.UnitOfMeasure.Id);
+            this.isDeleted = model.IsDeleted;
+            this.meter = model.Meter;
+            this.comparisonType = ComparisonTypeViewModel.Locate(model.Specification.ComparisonType);
+            this.SetModificationType(Shared.ModificationType.Update);
         }
 
         /// <summary>

--- a/Shared/Mobile-Rounds.ViewModels/Admin/Regions/RegionScreenViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Admin/Regions/RegionScreenViewModel.cs
@@ -106,6 +106,12 @@ namespace Mobile_Rounds.ViewModels.Admin.Regions
 
             var casted = regions.Select(r => new RegionViewModel(r, Save, Cancel));
             this.Regions.AddRange(casted);
+
+            var selectedRegionId = Navigator.GetNavigationData<Guid>();
+            if (selectedRegionId != null && selectedRegionId != Guid.Empty)
+            {
+                this.Selected = Regions.FirstOrDefault(s => s.Id == selectedRegionId);
+            }
         }
 
         public RegionScreenViewModel()

--- a/Shared/Mobile-Rounds.ViewModels/Admin/UnitOfMeasure/UnitOfMeasureViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Admin/UnitOfMeasure/UnitOfMeasureViewModel.cs
@@ -184,6 +184,17 @@ namespace Mobile_Rounds.ViewModels.Admin.UnitOfMeasure
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UnitOfMeasureModel"/> class.
+        /// This then caches the save and cancel commands so that it can
+        /// notify any views based on them.
+        /// </summary>
+        /// <param name="model">The data to copy into the view model.</param>
+        public UnitOfMeasureViewModel(UnitOfMeasureModel model)
+            : this(model, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnitOfMeasureModel"/> class.
         /// This is a copy constructor so all values will get copied to the new copy.
         /// </summary>
         /// <param name="toCopy">The object to copy.</param>

--- a/Shared/Mobile-Rounds.ViewModels/Models/StationModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Models/StationModel.cs
@@ -69,11 +69,9 @@ namespace Mobile_Rounds.ViewModels.Models
             : this()
         {
             this.NavigateRoot = region.NavigateRoot;
-            this.Navigate = new AsyncCommand(async(obj) =>
+            this.Navigate = new AsyncCommand((obj) =>
             {                
-                var file = Platform.ServiceResolver.Resolve<IFileHandler>();
-                var reads = await file.GetFileAsync("items.json");
-                var vm = new ReadingInputScreenViewModel(region, this, reads);
+                var vm = new ReadingInputScreenViewModel(region, this);
                 BaseViewModel.Navigator.Navigate(Shared.Navigation.NavigationType.StationInput, vm);
             });
         }

--- a/Shared/Mobile-Rounds.ViewModels/Regular/ReadingInput/ReadingInputScreenViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/ReadingInput/ReadingInputScreenViewModel.cs
@@ -24,7 +24,7 @@ namespace Mobile_Rounds.ViewModels.Regular.ReadingInput
         /// Initializes a new instance of the <see cref="ReadingInputScreenViewModel"/> class.
         /// Represents the full view model for the page.
         /// </summary>
-        public ReadingInputScreenViewModel(RegionModelSource region, StationModel station, string reads)
+        public ReadingInputScreenViewModel(RegionModelSource region, StationModel station)
         {
             var regionNav = new AsyncCommand((obj) =>
             {
@@ -35,8 +35,7 @@ namespace Mobile_Rounds.ViewModels.Regular.ReadingInput
             this.Crumbs.Add(new BreadcrumbItemModel(station.Name, station.Navigate));
             this.Input = new ReadingInputViewModel();
             this.ListModel = new ReadingInputListViewModel(this);
-            var result = JsonConvert.DeserializeObject<ItemHandler>(reads);
-            foreach (var item in result.Items)
+            foreach (var item in station.Items)
             {
                 if (item.StationId == station.Id)
                 {

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionModelSource.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Region/RegionModelSource.cs
@@ -3,6 +3,7 @@ using Mobile_Rounds.ViewModels.Platform;
 using Mobile_Rounds.ViewModels.Regular.Station;
 using Mobile_Rounds.ViewModels.Shared;
 using Mobile_Rounds.ViewModels.Shared.Commands;
+using Mobile_Rounds.ViewModels.Shared.DbModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,11 +38,13 @@ namespace Mobile_Rounds.ViewModels.Regular.Region
         public RegionModelSource(AsyncCommand navBack)
         {
             this.NavigateRoot = navBack;
-            this.Navigate = new AsyncCommand((obj) =>
+            this.Navigate = new AsyncCommand(async (obj) =>
             {
-                //var file = Platform.ServiceResolver.Resolve<IFileHandler>();
-                //var reads = await file.GetFileAsync("stations.json");
-                var vm = new StationListViewModel(this);
+                var file = Platform.ServiceResolver.Resolve<IFileHandler>();
+                var stations = await file.GetFileAsync<StationHandler>("stations.json");
+                var filtered = stations.Stations.Where(s => s.RegionId == this.Id);
+
+                var vm = new StationListViewModel(this, filtered);
                 BaseViewModel.Navigator.Navigate(Shared.Navigation.NavigationType.StationSelect, vm);
             });
         }

--- a/Shared/Mobile-Rounds.ViewModels/Regular/Station/StationListViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Regular/Station/StationListViewModel.cs
@@ -9,6 +9,8 @@ using Newtonsoft.Json;
 using Mobile_Rounds.ViewModels.Shared.DbModels;
 using System;
 using Mobile_Rounds.ViewModels.Regular.Region;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Mobile_Rounds.ViewModels.Regular.Station
 {
@@ -35,19 +37,19 @@ namespace Mobile_Rounds.ViewModels.Regular.Station
             }
         }
 
-        public StationListViewModel(RegionModelSource region)
+        public StationListViewModel(RegionModelSource region, IEnumerable<StationModel> stations)
         {
             this.Crumbs.Add(new Shared.Controls.BreadcrumbItemModel("Regions", region.NavigateRoot));
             this.Crumbs.Add(new Shared.Controls.BreadcrumbItemModel(region.Name, region.Navigate));
             this.Stations = new ObservableCollection<StationModel>();
-            //var result = JsonConvert.DeserializeObject<StationHandler>(reads);
-            foreach (var station in region.Stations)
+            foreach (var station in stations)
             {
                 this.Stations.Add(new StationModel(region)
                 {
                     Id = station.Id,
                     Name = station.Name,
-                    ItemCount = station.ItemCount
+                    ItemCount = station.Items.Count(),
+                    Items = station.Items
                 });
             }
         }

--- a/Shared/Mobile-Rounds.ViewModels/Shared/Home/HomePageViewModel.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Shared/Home/HomePageViewModel.cs
@@ -83,13 +83,16 @@ namespace Mobile_Rounds.ViewModels.Shared.Home
 
                 var stations = await request.GetAsync<List<StationModel>>(
                     $"{Constants.Endpoints.Stations}?{Constants.ApiOptions.ExcludeDeleted}");
+
+                foreach (var station in stations)
+                {
+                    var stationItems = await request.GetAsync<List<ItemModel>>(
+                        $"{Constants.Endpoints.Stations}/{station.Id}/items?{Constants.ApiOptions.ExcludeDeleted}");
+                    station.Items = stationItems;
+                }
+
                 var stationResult = new StationHandler() { Stations = stations };
                 await handler.SaveFileAsync("stations.json", stationResult);
-
-                var items = await request.GetAsync<List<ItemModel>>(
-                    $"{Constants.Endpoints.Items}?{Constants.ApiOptions.ExcludeDeleted}");
-                var itemResult = new ItemHandler() { Items = items };
-                await handler.SaveFileAsync("items.json", itemResult);
 
                 var units = await request.GetAsync<List<UnitOfMeasureModel>>(
                     $"{Constants.Endpoints.Units}?{Constants.ApiOptions.ExcludeDeleted}");

--- a/Shared/Mobile-Rounds.ViewModels/Shared/Navigation/INavigator.cs
+++ b/Shared/Mobile-Rounds.ViewModels/Shared/Navigation/INavigator.cs
@@ -20,8 +20,7 @@ namespace Mobile_Rounds.ViewModels.Shared.Navigation
         /// </summary>
         /// <typeparam name="T">The type of object you expect it to have.</typeparam>
         /// <returns>The previously stored data.</returns>
-        T GetNavigationData<T>()
-            where T : class;
+        T GetNavigationData<T>();
 
         /// <summary>
         /// Navigates to the specific type of screen.

--- a/Tablet/Mobile-Rounds/Helpers/NavigationService.cs
+++ b/Tablet/Mobile-Rounds/Helpers/NavigationService.cs
@@ -72,11 +72,10 @@ namespace Mobile_Rounds.Helpers
         }
 
         public T GetNavigationData<T>()
-            where T : class
         {
             if (this.navigationData == null)
             {
-                return null;
+                return default(T);
             }
 
             return (T)this.navigationData;

--- a/Tablet/Mobile-Rounds/Screens/Admin/Home/Index.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Admin/Home/Index.xaml
@@ -79,21 +79,21 @@
             Title="Stations"
             Command="{Binding GoToStations}" />
 
-        <controls:ColoredTile Grid.Row="2" Grid.Column="3"
+        <!--<controls:ColoredTile Grid.Row="2" Grid.Column="3"
             Margin="10"
             Foreground="White"
             Background="Purple" 
             Title="Items"
-            Command="{Binding GoToItems}" />
+            Command="{Binding GoToItems}" />-->
 
-        <controls:ColoredTile Grid.Row="2" Grid.Column="4"
+        <controls:ColoredTile Grid.Row="2" Grid.Column="3"
             Margin="10"
             Foreground="White"
             Background="Purple" 
             Title="Units of Measure"
             Command="{Binding GoToUnits}" />
 
-        <controls:ColoredTile Grid.Row="4" Grid.Column="1"
+        <controls:ColoredTile Grid.Row="2" Grid.Column="4"
             Margin="10"
             Foreground="White"
             Background="Purple" 

--- a/Tablet/Mobile-Rounds/Screens/Admin/Items/Index.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Admin/Items/Index.xaml
@@ -25,6 +25,8 @@
             <Setter Property="FontSize" Value="30"/>
         </Style>
         <converters:BooleanToVisibilityConverter x:Key="BoolToVis" />
+        <converters:InvertedBooleanToVisibilityConverter x:Key="InvBoolToVis" />
+        <converters:BoolToListColorConverter x:Key="BoolToListColor" />
     </Page.Resources>
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" x:Name="root">
@@ -75,16 +77,28 @@
             </breadcrumb:BreadcrumbControl.ItemTemplate>
         </breadcrumb:BreadcrumbControl>
 
+        <ProgressRing Margin="0, 20, 0, 0"
+            Grid.Column="1" Grid.Row="2" Grid.RowSpan="4" Grid.ColumnSpan="4"
+            Width="200" Height="200"
+            IsActive="{Binding IsLoading, Mode=TwoWay}" 
+            Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource BoolToVis}}"/>
+
         <!-- Content -->
         <TextBlock Grid.Row="2" Grid.Column="1" FontSize="30" Text="Available Items" Padding="0,0,0,15"/>
         <ListView ItemsSource="{Binding Items, Mode=TwoWay}" 
+                  Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}"
                   Grid.Row="3" Grid.Column="1" SelectionMode="Single"
                   Grid.RowSpan="6" ScrollViewer.VerticalScrollBarVisibility="Auto"
                   ScrollViewer.VerticalScrollMode="Enabled"
                   SelectedItem="{Binding Selected, Mode=TwoWay}" Margin="0, 0, 25, 25">
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch"></Setter>
+                </Style>
+            </ListView.ItemContainerStyle>
             <ListView.ItemTemplate>
                 <DataTemplate>
-                    <StackPanel Orientation="Vertical">
+                    <StackPanel Orientation="Vertical" Background="{Binding IsDeleted, Converter={StaticResource BoolToListColor}}">
                         <TextBlock Text="{Binding Name}" FontSize="22" Foreground="Purple"/>
                         <TextBlock Text="{Binding Meter}" FontSize="18" Foreground="Purple" Padding="8, 0, 0, 10"/>
                     </StackPanel>
@@ -93,7 +107,8 @@
         </ListView>
 
         <TextBlock Grid.Row="2" Grid.Column="2" Text="Add/Modify Item" Style="{StaticResource SectionHeader}" Margin="0,0,0,15"/>
-        <ScrollViewer Grid.Row="3" Grid.Column="2" Grid.RowSpan="4" VerticalAlignment="Top">
+        <ScrollViewer Grid.Row="3" Grid.Column="2" Grid.RowSpan="4" VerticalAlignment="Top" 
+                      Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}">
             <StackPanel DataContext="{Binding CurrentItem, Mode=TwoWay}" Padding="0,0,15,0">
                 <TextBox Text="{Binding Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Style="{StaticResource TextInput}">
                     <TextBox.HeaderTemplate>
@@ -134,18 +149,25 @@
                     </TextBox.HeaderTemplate>
                 </TextBox>
                 <ComboBox HorizontalAlignment="Stretch" VerticalAlignment="Center" Margin="0,0,0,15" 
-                      ItemsSource="{Binding Units}" SelectedItem="{Binding Unit, Mode=TwoWay}" DisplayMemberPath="Name" FontSize="18">
+                      ItemsSource="{Binding Units, Mode=TwoWay}" SelectedItem="{Binding Unit, Mode=TwoWay}" DisplayMemberPath="Name" FontSize="18">
                     <ComboBox.HeaderTemplate>
                         <DataTemplate>
                             <TextBlock FontSize="22" Text="Unit Type" />
                         </DataTemplate>
                     </ComboBox.HeaderTemplate>
                 </ComboBox>
+
+                <TextBlock VerticalAlignment="Top" HorizontalAlignment="Stretch"
+                   Margin="0,0,0,15" Text="Is Deleted?"/>
+
+                <CheckBox IsChecked="{Binding IsDeleted, Mode=TwoWay}"
+                  Margin="0,0,0,30" Width="50" Height="50" FontSize="36"/>
             </StackPanel>
 
         </ScrollViewer>
         
-        <Grid Grid.Row="7" Grid.RowSpan="2" Grid.Column="2" VerticalAlignment="Bottom" Margin="0, -60, 0, 0">
+        <Grid Grid.Row="7" Grid.RowSpan="2" Grid.Column="2" VerticalAlignment="Bottom" Margin="0, -60, 0, 0"
+              Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
                 <ColumnDefinition Width="*" />

--- a/Tablet/Mobile-Rounds/Screens/Admin/Items/Index.xaml.cs
+++ b/Tablet/Mobile-Rounds/Screens/Admin/Items/Index.xaml.cs
@@ -29,5 +29,12 @@ namespace Mobile_Rounds.Screens.Admin.Items
             this.DataContext = BaseViewModel.Navigator.GetNavigationData<ItemScreenViewModel>();
             this.InitializeComponent();
         }
+
+        protected override async void OnNavigatedTo(NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            var vm = this.DataContext as ItemScreenViewModel;
+            await vm.LoadDataAsync();
+        }
     }
 }

--- a/Tablet/Mobile-Rounds/Screens/Admin/Stations/Index.xaml
+++ b/Tablet/Mobile-Rounds/Screens/Admin/Stations/Index.xaml
@@ -104,7 +104,12 @@
                    Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}"
                    Grid.Column="1" Grid.Row="4"
                   Margin="0,0,0,30" Width="50" Height="50" FontSize="36"/>
-
+        
+        <Button Grid.Row="4" Grid.Column="2" Grid.ColumnSpan="1" Margin="10, 0, 0, 0"
+            Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}"
+            Background="Orange" Foreground="White" Height="100" HorizontalContentAlignment="Center"
+            Content="Edit Items" HorizontalAlignment="Stretch" Command="{Binding NavigateToItems}"
+            VerticalAlignment="Bottom" FontSize="36" RequestedTheme="Light"/>
 
         <ListView ItemsSource="{Binding Stations, Mode=TwoWay}" 
                   Visibility="{Binding IsLoading, Mode=TwoWay, Converter={StaticResource InvBoolToVis}}"


### PR DESCRIPTION
This also includes a few other things:
1. Fixed bugs with server side data being sent back incorrectly.
2. Fixed items API for when returninng data after an insert throwing exceptions.
3. Added new Edit Items button to stations admin view.
4. Refactored local file storage to only get items related to the stations, rather than all items then filter them out. This is done by now calling the /api/stations/id/items endpoint, rather than saving all the items.
5. Other misc fixes.